### PR TITLE
Outputted motor values.

### DIFF
--- a/frc971/control_loops/drivetrain/drivetrain.cc
+++ b/frc971/control_loops/drivetrain/drivetrain.cc
@@ -127,13 +127,9 @@ void DrivetrainLoop::RunIteration(
 
   if (control_loop_driving) {
     dt_closedloop_.Update(output == NULL, true);
-#ifdef INCLUDE_971_INFRASTRUCTURE
     dt_closedloop_.SendMotors(output);
-#endif //INCLUDE_971_INFRASTRUCTURE
   } else {
-#ifdef INCLUDE_971_INFRASTRUCTURE
     dt_openloop_.SendMotors(output);
-#endif //INCLUDE_971_INFRASTRUCTURE
     if (output) {
       dt_closedloop_.SetExternalMotors(output->left_voltage,
                                        output->right_voltage);

--- a/frc971/control_loops/drivetrain/polydrivetrain.cc
+++ b/frc971/control_loops/drivetrain/polydrivetrain.cc
@@ -389,6 +389,9 @@ void PolyDrivetrain::Update() {
 #ifdef INCLUDE_971_INFRASTRUCTURE
 void PolyDrivetrain::SendMotors(
     ::frc971::control_loops::DrivetrainQueue::Output *output) {
+#else  //INCLUDE_971_INFRASTRUCTURE
+void PolyDrivetrain::SendMotors(DrivetrainOutput *output) {
+#endif //INCLUDE_971_INFRASTRUCTURE
   if (output != NULL) {
     output->left_voltage = loop_->U(0, 0);
     output->right_voltage = loop_->U(1, 0);
@@ -396,7 +399,6 @@ void PolyDrivetrain::SendMotors(
     output->right_high = right_gear_ == HIGH || right_gear_ == SHIFTING_UP;
   }
 }
-#endif //INCLUDE_971_INFRASTRUCTURE
 
 
 }  // namespace drivetrain

--- a/frc971/control_loops/drivetrain/polydrivetrain.h
+++ b/frc971/control_loops/drivetrain/polydrivetrain.h
@@ -54,6 +54,8 @@ class PolyDrivetrain {
 
 #ifdef INCLUDE_971_INFRASTRUCTURE
   void SendMotors(::frc971::control_loops::DrivetrainQueue::Output *output);
+#else //INCLUDE_971_INFRASTRUCTURE
+  void SendMotors(DrivetrainOutput *output);
 #endif //INCLUDE_971_INFRASTRUCTURE
 
  private:

--- a/frc971/control_loops/drivetrain/ssdrivetrain.cc
+++ b/frc971/control_loops/drivetrain/ssdrivetrain.cc
@@ -177,6 +177,9 @@ double DrivetrainMotorsSS::GetEstimatedRobotSpeed() const {
 #ifdef INCLUDE_971_INFRASTRUCTURE
 void DrivetrainMotorsSS::SendMotors(
     ::frc971::control_loops::DrivetrainQueue::Output *output) const {
+#else  //INCLUDE_971_INFRASTRUCTURE
+void DrivetrainMotorsSS::SendMotors(DrivetrainOutput *output) {
+#endif //INCLUDE_971_INFRASTRUCTURE
   if (output) {
     output->left_voltage = loop_->U(0, 0);
     output->right_voltage = loop_->U(1, 0);
@@ -184,7 +187,6 @@ void DrivetrainMotorsSS::SendMotors(
     output->right_high = true;
   }
 }
-#endif //INCLUDE_971_INFRASTRUCTURE
 
 
 }  // namespace drivetrain

--- a/frc971/control_loops/drivetrain/ssdrivetrain.h
+++ b/frc971/control_loops/drivetrain/ssdrivetrain.h
@@ -74,6 +74,8 @@ class DrivetrainMotorsSS {
 #ifdef INCLUDE_971_INFRASTRUCTURE
   void SendMotors(
       ::frc971::control_loops::DrivetrainQueue::Output *output) const;
+#else //INCLUDE_971_INFRASTRUCTURE
+  void SendMotors(DrivetrainOutput *output);
 #endif //INCLUDE_971_INFRASTRUCTURE
 
   const LimitedDrivetrainLoop &loop() const { return *loop_; }


### PR DESCRIPTION
The motor values weren't being put in the output structure.  This
puts the code back in which does that.
