### PR TITLE
Fixed bug where PolyDrivetrain only measured 0 velocity.

### DIFF
--- a/frc971/control_loops/drivetrain/drivetrain.cc
+++ b/frc971/control_loops/drivetrain/drivetrain.cc
@@ -35,15 +35,18 @@ DrivetrainLoop::DrivetrainLoop(
     ::frc971::control_loops::DrivetrainQueue *my_drivetrain)
     : aos::controls::ControlLoop<::frc971::control_loops::DrivetrainQueue>(
           my_drivetrain),
-      :dt_config_(dt_config),
-      kf_(dt_config_.make_kf_drivetrain_loop()) {
+      : dt_config_(dt_config),
+        kf_(dt_config_.make_kf_drivetrain_loop()),
+        dt_openloop_(dt_config_, &kf_),
+        dt_closedloop_(dt_config_) {
   ::aos::controls::HPolytope<0>::Init();
 }
 #else //INCLUDE_971_INFRASTRUCTURE
-DrivetrainLoop::DrivetrainLoop(
-    const DrivetrainConfig &dt_config)
-      :dt_config_(dt_config),
-      kf_(dt_config_.make_kf_drivetrain_loop()) {
+DrivetrainLoop::DrivetrainLoop(const DrivetrainConfig &dt_config)
+    : dt_config_(dt_config),
+      kf_(dt_config_.make_kf_drivetrain_loop()),
+      dt_openloop_(dt_config_, &kf_),
+      dt_closedloop_(dt_config_) {
   ::aos::controls::HPolytope<0>::Init();
 }
 #endif //INCLUDE_971_INFRASTRUCTURE

--- a/frc971/control_loops/drivetrain/drivetrain.h
+++ b/frc971/control_loops/drivetrain/drivetrain.h
@@ -72,9 +72,9 @@ virtual void RunIteration(
 
   const DrivetrainConfig dt_config_;
 
-  PolyDrivetrain dt_openloop_{dt_config_};
-  DrivetrainMotorsSS dt_closedloop_{dt_config_};
   StateFeedbackLoop<7, 2, 3> kf_;
+  PolyDrivetrain dt_openloop_;
+  DrivetrainMotorsSS dt_closedloop_;
 };
 
 }  // namespace drivetrain

--- a/frc971/control_loops/drivetrain/polydrivetrain.cc
+++ b/frc971/control_loops/drivetrain/polydrivetrain.cc
@@ -124,8 +124,13 @@ void PolyDrivetrain::UpdateGears(Gear requested_gear) {
 
 void PolyDrivetrain::SetGoal(double wheel, double throttle, bool quickturn,
                              bool highgear) {
+  // Wheel nonlinearity.  Should be between like 0.05 and 1.0
   const double kWheelNonLinearity = 0.3;
-  // Apply a sin function that's scaled to make it feel better.
+  // Apply a sin function that's scaled to make it feel better.  Larger
+  // nonlinearities will make it such that more wheel motion is required for the
+  // same turn rate.  This re-allocates wheel range such that more wheel range
+  // is used for fine steering adjustments and less is used for changing the
+  // radius when the robot is almost turning around the inner wheel.
   const double angular_range = M_PI_2 * kWheelNonLinearity;
 
   if (dt_config_.shifter_type == ShifterType::SIMPLE_SHIFTER) {
@@ -140,6 +145,7 @@ void PolyDrivetrain::SetGoal(double wheel, double throttle, bool quickturn,
 
   wheel_ = sin(angular_range * wheel) / sin(angular_range);
   wheel_ = sin(angular_range * wheel_) / sin(angular_range);
+  wheel_ = 2.0 * wheel - wheel_;
 
   quickturn_ = quickturn;
 

--- a/frc971/control_loops/drivetrain/polydrivetrain.cc
+++ b/frc971/control_loops/drivetrain/polydrivetrain.cc
@@ -30,8 +30,9 @@ using ::frc971::control_loops::CIMLogging;
 #endif //INCLUDE_971_INFRASTRUCTURE
 using ::frc971::control_loops::CoerceGoal;
 
-PolyDrivetrain::PolyDrivetrain(const DrivetrainConfig &dt_config)
-    : kf_(dt_config.make_kf_drivetrain_loop()),
+PolyDrivetrain::PolyDrivetrain(const DrivetrainConfig &dt_config,
+                               StateFeedbackLoop<7, 2, 3> *kf)
+    : kf_(kf),
       U_Poly_((Eigen::Matrix<double, 4, 2>() << /*[[*/ 1, 0 /*]*/,
                /*[*/ -1, 0 /*]*/,
                /*[*/ 0, 1 /*]*/,
@@ -278,8 +279,8 @@ double PolyDrivetrain::MaxVelocity() {
 
 void PolyDrivetrain::Update() {
   if (!dt_config_.open_loop) {
-    loop_->mutable_X_hat()(0, 0) = kf_.X_hat()(1, 0);
-    loop_->mutable_X_hat()(1, 0) = kf_.X_hat()(3, 0);
+    loop_->mutable_X_hat()(0, 0) = kf_->X_hat()(1, 0);
+    loop_->mutable_X_hat()(1, 0) = kf_->X_hat()(3, 0);
   }
 
   // TODO(austin): Observer for the current velocity instead of difference

--- a/frc971/control_loops/drivetrain/polydrivetrain.h
+++ b/frc971/control_loops/drivetrain/polydrivetrain.h
@@ -17,7 +17,8 @@ class PolyDrivetrain {
  public:
   enum Gear { HIGH, LOW, SHIFTING_UP, SHIFTING_DOWN };
 
-  PolyDrivetrain(const DrivetrainConfig &dt_config);
+  PolyDrivetrain(const DrivetrainConfig &dt_config,
+                 StateFeedbackLoop<7, 2, 3> *kf);
 
   int controller_index() const { return loop_->controller_index(); }
 
@@ -59,7 +60,7 @@ class PolyDrivetrain {
 #endif //INCLUDE_971_INFRASTRUCTURE
 
  private:
-  StateFeedbackLoop<7, 2, 3> kf_;
+  StateFeedbackLoop<7, 2, 3> *kf_;
 
   const ::aos::controls::HPolytope<2> U_Poly_;
 


### PR DESCRIPTION
kf_ got modified to be a new object in PolyDrivetrain instead of
using the one from Drivetrain which is actually updated.  This
resulted in 0 measured velocity.

I tested a very similar modification on 971's robot today.  It took a couple hours to figure it out.
